### PR TITLE
:bug: Fix npm badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Provider Stack [![npm version](https://badge.fury.io/js/@opencreek%2Fprovider-stack.svg)](https://badge.fury.io/js/@opencreek%2Fprovider-stack)
+## Provider Stack ![npm](https://img.shields.io/npm/v/@opencreek/provider-stack)
 
 Are you tired of the mountain of react providers, just lying in your app.tsx?
 This simple library solves that for you!

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "registry": "https://registry.npmjs.org/",
         "access": "public"
     },
-    "repository": "https://github.com/github/opencreek/provider-stack",
+    "repository": "https://github.com/opencreek/provider-stack",
     "license": "MIT",
     "devDependencies": {
         "@auto-it/all-contributors": "^10.32.2",


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.2.2--canary.3.1450539597.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @opencreek/provider-stack@0.2.2--canary.3.1450539597.0
  # or 
  yarn add @opencreek/provider-stack@0.2.2--canary.3.1450539597.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
